### PR TITLE
Fix breaking pipenv travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,14 @@ python:
   - '3.6.5'
 services:
   - postgresql
-env:
-  - PIPENV_IGNORE_VIRTUALENVS=1
 install:
-  - make bootstrap
+  - pip install -r requirements.txt
+before_script:
+  - make create_db
+  - python ./manage.py migrate
 script:
-  - make lint
-  - make test
+  - flake8
+  - pytest
 notifications:
   email: false
   slack:


### PR DESCRIPTION
This is possibly due to a problem with pipenv so in the mean time swap back to using the default install.